### PR TITLE
Update to latest bootswatch upstream version (3.3.5+4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-target
+target/
+.settings/
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <upstream.version>3.3.5</upstream.version>
-    <upstream.folderVersion>3.3.5</upstream.folderVersion>
+    <upstream.version>3.3.5+4</upstream.version>
+    <upstream.folderVersion>3.3.5-4</upstream.folderVersion>
     <upstream.url>https://github.com/thomaspark/bootswatch/archive</upstream.url>
     <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
   </properties>


### PR DESCRIPTION
FIXS: [ Corrupt Font files #19 ](https://github.com/webjars/bootswatch/issues/19)